### PR TITLE
feat: update countdown format and remove personal data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Kleine Ein-Seiten-Website, die zeigt:
 Öffne `script.js` und passe bei Bedarf die Konstanten oben im File an:
 
 ```js
-const PARTNER_NAME = "Philipp";
-const BIRTH_YMD  = [1991, 7, 3];     // Jahr, Monat, Tag
-const COUPLE_YMD = [2009, 8, 28];
+const PARTNER_NAME = "NAME";
+const BIRTH_YMD  = [1990, 1, 1];     // Jahr, Monat, Tag
+const COUPLE_YMD = [2010, 1, 1];
 ```
 
 > Die Berechnung geschieht über reine *Kalendertage* (UTC-Mitternacht), um Off-by-One-Probleme durch Zeitzonen und Sommerzeit zu vermeiden.
@@ -24,7 +24,7 @@ Einfach `index.html` im Browser öffnen.
 
 ## Veröffentlichung mit GitHub Pages (Benutzerseite)
 
-1. Lege auf GitHub ein neues Repository an, dessen Name **`DEINNAME.github.io`** ist. Beispiel: `philipp-schlueter.github.io`.
+1. Lege auf GitHub ein neues Repository an, dessen Name **`DEINNAME.github.io`** ist. Beispiel: `benutzername.github.io`.
 2. Lade die Dateien `index.html`, `style.css`, `script.js` (und optional `README.md`) ins Repo (über Web-UI oder per Git).
 3. Öffne **Settings → Pages** und stelle unter *Build and deployment* „**Deploy from a branch**“, Branch `main`, Ordner `/ (root)` ein. Speichern.
 4. Rufe anschließend `https://DEINNAME.github.io` im Browser auf.

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       <p class="lead">
         Du bist jetzt seit
         <span class="big-number" id="daysTogether">—</span>
-        Tagen mit <span id="partnerName">Philipp</span> zusammen.
+        Tagen mit <span id="partnerName">—</span> zusammen.
       </p>
       <p class="lead">
         Das sind
@@ -41,10 +41,9 @@
       <div>
         <h2 class="subtle">Countdown</h2>
         <div class="countdown" id="countdown">
+          <div class="cd-item"><span class="cd-num" id="cd-years">—</span><span class="cd-label">Jahre</span></div>
+          <div class="cd-item"><span class="cd-num" id="cd-months">—</span><span class="cd-label">Monate</span></div>
           <div class="cd-item"><span class="cd-num" id="cd-days">—</span><span class="cd-label">Tage</span></div>
-          <div class="cd-item"><span class="cd-num" id="cd-hours">—</span><span class="cd-label">Stunden</span></div>
-          <div class="cd-item"><span class="cd-num" id="cd-mins">—</span><span class="cd-label">Minuten</span></div>
-          <div class="cd-item"><span class="cd-num" id="cd-secs">—</span><span class="cd-label">Sekunden</span></div>
         </div>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 // Alle Konstanten hier anpassen, falls nötig.
-const PARTNER_NAME = "Philipp";
+const PARTNER_NAME = "NAME";
 // Zivile Daten: Jahr, Monat (1-12), Tag (1-31)
-const BIRTH_YMD = [1991, 7, 3];      // 3. Juli 1991
-const COUPLE_YMD = [2009, 8, 28];    // 28. August 2009
+const BIRTH_YMD = [1990, 1, 1];      // 1. Januar 1990
+const COUPLE_YMD = [2010, 1, 1];    // 1. Januar 2010
 
 // Hilfsfunktionen: Kalendertage-Differenz robust gegen Zeitzonen
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -61,39 +61,43 @@ function compute() {
 }
 
 function startCountdown(targetDateUTC) {
+  const cdYears = document.getElementById("cd-years");
+  const cdMonths = document.getElementById("cd-months");
   const cdDays = document.getElementById("cd-days");
-  const cdHours = document.getElementById("cd-hours");
-  const cdMins = document.getElementById("cd-mins");
-  const cdSecs = document.getElementById("cd-secs");
+
+  function diffYMD(from, to) {
+    let years = to.getUTCFullYear() - from.getUTCFullYear();
+    let months = to.getUTCMonth() - from.getUTCMonth();
+    let days = to.getUTCDate() - from.getUTCDate();
+
+    if (days < 0) {
+      const prevMonth = new Date(Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), 0));
+      days += prevMonth.getUTCDate();
+      months--;
+    }
+    if (months < 0) {
+      months += 12;
+      years--;
+    }
+    return { years, months, days };
+  }
 
   function tick() {
-    const now = new Date();
-    // Zielzeit als UTC-Mitternacht dieses Tages
-    const targetMs = Date.UTC(targetDateUTC.getUTCFullYear(), targetDateUTC.getUTCMonth(), targetDateUTC.getUTCDate(), 0, 0, 0);
-    const nowMs = now.getTime();
-    let diff = Math.floor((targetMs - nowMs) / 1000); // Sekunden
-
-    if (diff <= 0) {
+    const today = todayUTCDateOnly();
+    if (today >= targetDateUTC) {
+      cdYears.textContent = "0";
+      cdMonths.textContent = "0";
       cdDays.textContent = "0";
-      cdHours.textContent = "0";
-      cdMins.textContent = "0";
-      cdSecs.textContent = "0";
       return;
     }
-
-    const days = Math.floor(diff / (24 * 3600)); diff -= days * 24 * 3600;
-    const hours = Math.floor(diff / 3600); diff -= hours * 3600;
-    const mins = Math.floor(diff / 60); diff -= mins * 60;
-    const secs = diff;
-
+    const { years, months, days } = diffYMD(today, targetDateUTC);
+    cdYears.textContent = formatIntDE(years);
+    cdMonths.textContent = formatIntDE(months);
     cdDays.textContent = formatIntDE(days);
-    cdHours.textContent = hours.toString().padStart(2, "0");
-    cdMins.textContent = mins.toString().padStart(2, "0");
-    cdSecs.textContent = secs.toString().padStart(2, "0");
   }
 
   tick();
-  setInterval(tick, 1000);
+  setInterval(tick, 60 * 60 * 1000);
 }
 
 document.addEventListener("DOMContentLoaded", compute);


### PR DESCRIPTION
## Summary
- scrub personal examples from docs and defaults
- show countdown in years, months and days

## Testing
- `node - <<'NODE'
function diffYMD(from, to) {
  let years = to.getUTCFullYear() - from.getUTCFullYear();
  let months = to.getUTCMonth() - from.getUTCMonth();
  let days = to.getUTCDate() - from.getUTCDate();
  if (days < 0) {
    const prevMonth = new Date(Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), 0));
    days += prevMonth.getUTCDate();
    months--;
  }
  if (months < 0) {
    months += 12;
    years--;
  }
  return { years, months, days };
}
console.log(diffYMD(new Date(Date.UTC(2023,0,15)), new Date(Date.UTC(2025,5,20))));
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bbb9fba88328999b93666f49e266