### PR TITLE
Fix countdown initialization on GitHub Pages

### DIFF
--- a/script.js
+++ b/script.js
@@ -100,4 +100,8 @@ function startCountdown(targetDateUTC) {
   setInterval(tick, 60 * 60 * 1000);
 }
 
-document.addEventListener("DOMContentLoaded", compute);
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", compute);
+} else {
+  compute();
+}


### PR DESCRIPTION
## Summary
- Ensure countdown computes immediately if DOMContentLoaded already fired

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4c88bfc44832892fde53b97e3d923